### PR TITLE
Extending location api with depth paremeter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 
 def read(*parts):
-    return codecs.open(os.path.join(here, *parts), 'r').read()
+    return codecs.open(os.path.join(here, *parts), 'r', 'utf-8').read()
 
 
 def find_version(*file_paths):


### PR DESCRIPTION
@edevenport @nurfet-becirevic @jasmingacic 
This  is required because SDK is not able to increase depth on the location api so it could get imageAlias for a required location.

Could you please review PR.